### PR TITLE
Setup ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                   name: publish current
                   command: |
                       echo $VERIFY_DOCKERHUB_PW |docker login -u verifyusi --password-stdin
-                      echo "docker push verifyusi/verify-env:current"
+                      docker push verifyusi/verify-env:current
 
     build-starexec:
         docker:
@@ -37,7 +37,7 @@ jobs:
                   name: publish starexec
                   command: |
                       echo $VERIFY_DOCKERHUB_PW |docker login -u verifyusi --password-stdin
-                      echo "docker push verifyusi/verify-env:starexec"
+                      docker push verifyusi/verify-env:starexec
 
 workflows:
     build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2.1
+jobs:
+    build-current:
+        docker:
+            - image: cimg/base:current
+              auth:
+                  username: mydockerhub-user
+                  password: $DOCKERHUB_PASSWORD
+        steps:
+            - checkout
+            - setup_remote_docker:
+                docker_layer_caching: true
+            - run:
+                  name: Build current
+                  command: |
+                      DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-current --rm -t verifyusi/verify-env:current .
+            - run:
+                  name: publish current
+                  command: |
+                      echo $DOCKERHUB_PASS |docker login -u $DOCKER_USER --password-stdin
+                      echo "docker push verifyusi/verify-env:current"
+
+    build-starexec:
+        docker:
+            - image: cimg/base:current
+              auth:
+                  username: mydockerhub-user
+                  password: $DOCKERHUB_PASSWORD
+        steps:
+            - checkout
+            - setup_remote_docker:
+                docker_layer_caching: true
+            - run:
+                  name: build starexec
+                  command: DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-starexec --rm -t verifyusi/verify-env:starexec .
+            - run:
+                  name: publish starexec
+                  command: |
+                      echo $DOCKERHUB_PASS |docker login -u $DOCKER_USER --password-stdin
+                      echo "docker push verifyusi/verify-env:starexec"
+
+workflows:
+    build-test:
+        jobs:
+          - build-current:
+            filters: &filters-build-test
+              tags:
+                only: /^v.*/
+          - build-starexec:
+            filters:
+              <<: *filters-build-test
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs:
         docker:
             - image: cimg/base:current
               auth:
-                  username: mydockerhub-user
-                  password: $DOCKERHUB_PASSWORD
+                  username: verifyusi
+                  password: $VERIFY_DOCKERHUB_PW
         steps:
             - checkout
             - setup_remote_docker:
@@ -17,15 +17,15 @@ jobs:
             - run:
                   name: publish current
                   command: |
-                      echo $DOCKERHUB_PASS |docker login -u $DOCKER_USER --password-stdin
+                      echo $VERIFY_DOCKERHUB_PW |docker login -u verifyusi --password-stdin
                       echo "docker push verifyusi/verify-env:current"
 
     build-starexec:
         docker:
             - image: cimg/base:current
               auth:
-                  username: mydockerhub-user
-                  password: $DOCKERHUB_PASSWORD
+                  username: verifyusi
+                  password: $VERIFY_DOCKERHUB_PW
         steps:
             - checkout
             - setup_remote_docker:
@@ -36,18 +36,22 @@ jobs:
             - run:
                   name: publish starexec
                   command: |
-                      echo $DOCKERHUB_PASS |docker login -u $DOCKER_USER --password-stdin
+                      echo $VERIFY_DOCKERHUB_PW |docker login -u verifyusi --password-stdin
                       echo "docker push verifyusi/verify-env:starexec"
 
 workflows:
     build-test:
         jobs:
           - build-current:
-            filters: &filters-build-test
-              tags:
-                only: /^v.*/
+              filters: &filters-build-test
+                tags:
+                  only: /^v.*/
+              context:
+                - verify-docker
           - build-starexec:
-            filters:
-              <<: *filters-build-test
+              filters:
+                <<: *filters-build-test
+              context:
+                - verify-docker
 
 


### PR DESCRIPTION
This PR suggests how to organise the building of the custom docker images of the group that we use currently to speed-up builds in circleci.

The idea is to build and push the docker images to dockerhub at every commit.

Group's dockerhub password is passed in the `verify-docker` context's `VERIFY_DOCKERHUB_PW` environment variable.

I also plan to set up a scheduled workflow for the repository that will build and push the docker images monthly, following CircleCI's schedule for updating the image `cimg/base:current` used by one of the images.
