### PR TITLE
CI: Fix docker organisation name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
         docker:
             - image: cimg/base:current
               auth:
-                  username: verifyusi
+                  username: $VERIFY_DOCKERHUB_USER
                   password: $VERIFY_DOCKERHUB_PW
         steps:
             - checkout
@@ -13,18 +13,18 @@ jobs:
             - run:
                   name: Build current
                   command: |
-                      DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-current --rm -t verifyusi/verify-env:current .
+                      DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-current --rm -t usiverify/verify-env:current .
             - run:
                   name: publish current
                   command: |
-                      echo $VERIFY_DOCKERHUB_PW |docker login -u verifyusi --password-stdin
-                      docker push verifyusi/verify-env:current
+                      echo $VERIFY_DOCKERHUB_PW |docker login -u $VERIFY_DOCKERHUB_USER --password-stdin
+                      docker push usiverify/verify-env:current
 
     build-starexec:
         docker:
             - image: cimg/base:current
               auth:
-                  username: verifyusi
+                  username: $VERIFY_DOCKERHUB_USER
                   password: $VERIFY_DOCKERHUB_PW
         steps:
             - checkout
@@ -32,12 +32,12 @@ jobs:
                 docker_layer_caching: true
             - run:
                   name: build starexec
-                  command: DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-starexec --rm -t verifyusi/verify-env:starexec .
+                  command: DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-starexec --rm -t usiverify/verify-env:starexec .
             - run:
                   name: publish starexec
                   command: |
-                      echo $VERIFY_DOCKERHUB_PW |docker login -u verifyusi --password-stdin
-                      docker push verifyusi/verify-env:starexec
+                      echo $VERIFY_DOCKERHUB_PW |docker login -u $VERIFY_DOCKERHUB_USER --password-stdin
+                      docker push usiverify/verify-env:starexec
 
 workflows:
     build-test:

--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ Docker files for building USI verification group CI images
 To compile:
 
 ```
-DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-current --rm -t verifyusi/verify-env:current .
+DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-current --rm -t usiverify/verify-env:current .
 ```
 
 To publish:
 ```
-docker push verifyusi/verify-env:current
+docker push usiverify/verify-env:current
 ```
 
 ## Starexec
 
 To compile:
 ```
-DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-starexec --rm -t verifyusi/verify-env:starexec .
+DOCKER_BUILDKIT=1 docker build -f Dockerfile-verify-starexec --rm -t usiverify/verify-env:starexec .
 ```
 
 To publish:
 ```
-docker push verifyusi/verify-env:starexec
+docker push usiverify/verify-env:starexec
 ```
 


### PR DESCRIPTION
This PR fixes two issues:
  - The docker organisation name is wrong.  It should be `usiverify`.
  - The dockerhub user name was hard coded to the circleci config.  Since the group's dockerhub organisation has limited "seats", I suggest to use a circleci environmen variable from the context instead.  At the moment in circleci the user name is set to my username, but this should be changed in the future.