### PR TITLE
Added simple dockerfile for latest Arch Linux

### DIFF
--- a/Dockerfile-verify-archlinux
+++ b/Dockerfile-verify-archlinux
@@ -1,0 +1,11 @@
+FROM archlinux:latest
+
+RUN pacman -Syyu --noconfirm \
+    clang \
+    make \
+    cmake \
+    git \
+    libedit \
+    bison \
+    flex \
+    gmp

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Example:
 
 Possible commands are `build`, `push` and `run`.
 
-Possible images are `current`, `fedora` and `ubuntu`.
+Possible images are `current`, `fedora`, `ubuntu`, and `archlinux`.
 
 Image `current` is based on `cimg/base:current` which is an image dedicated to CircleCI, making it well suitable for stable CI builds.
 However, as a consequence, this image does not provide the latest packages, which may cause troubles in cases such as using `clang-format` where some bugs are fixed only in the latest releases.

--- a/docker.sh
+++ b/docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CMDS=(build push run)
-IMAGES=(current fedora ubuntu)
+IMAGES=(current fedora ubuntu archlinux)
 
 function print_array {
   local -n ary=$1


### PR DESCRIPTION
In the end, even the latest Ubuntu was not sufficient for `clang-format` - its version is `18.1.3` and it still contains a bug which is fixed in `18.1.4` :) (the current version is `18.1.8`.
Since formatting is rather about us developers with the (almost) latest packages, we include a bleeding-edge distro - Arch Linux.